### PR TITLE
fix: WebSocket auth loop and HTTP endpoint 401s

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -147,11 +147,24 @@ function connect() {
 
   ws = new WebSocket(url);
 
-  ws.onopen = () => {
+  ws.onopen = async () => {
     terminal.log('[ws] Connected to server', 'info');
     if (reconnectTimer) {
       clearTimeout(reconnectTimer);
       reconnectTimer = null;
+    }
+    try {
+      const resp = await fetch('/api/auth/local-token');
+      if (resp.ok) {
+        const { token } = await resp.json();
+        ws.send(JSON.stringify({ type: 'auth', token }));
+        voice.setToken(token);
+        office.setToken(token);
+      } else {
+        console.error('[ws] Failed to fetch local token:', resp.status);
+      }
+    } catch (err) {
+      console.error('[ws] Failed to fetch local token:', err);
     }
   };
 

--- a/public/js/office.js
+++ b/public/js/office.js
@@ -129,8 +129,19 @@ function createAgent(id, xPct, yPct, color, label, isBoss) {
 
 function randomWanderDelay() { return 8000 + Math.random() * 7000; }
 
+let sessionToken = null;
+
+export function setToken(token) {
+  sessionToken = token;
+}
+
 async function fetchWeather() {
-  try { const r = await fetch('/api/weather'); if (r.ok) weather = await r.json(); } catch (e) {}
+  try {
+    const r = await fetch('/api/weather', {
+      headers: sessionToken ? { 'Authorization': `Bearer ${sessionToken}` } : {},
+    });
+    if (r.ok) weather = await r.json();
+  } catch (e) {}
 }
 async function fetchHealth() {
   try { const r = await fetch('/api/health'); if (r.ok) health = await r.json(); } catch (e) {}

--- a/public/js/voice.js
+++ b/public/js/voice.js
@@ -7,6 +7,11 @@ let isRecording = false;
 let onTranscription = null; // callback(text)
 let silenceTimer = null;
 let targetAgent = 'main';
+let sessionToken = null;
+
+export function setToken(token) {
+  sessionToken = token;
+}
 
 const MAX_RECORD_SECONDS = 15;
 
@@ -96,6 +101,7 @@ async function sendToServer(blob) {
   try {
     const res = await fetch('/api/voice/transcribe', {
       method: 'POST',
+      headers: sessionToken ? { 'Authorization': `Bearer ${sessionToken}` } : {},
       body: form,
     });
 
@@ -117,7 +123,10 @@ export async function playSpokenResponse(text, agentId = 'main') {
   try {
     const res = await fetch('/api/voice/speak', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        ...(sessionToken ? { 'Authorization': `Bearer ${sessionToken}` } : {}),
+      },
       body: JSON.stringify({ text, agent: agentId }),
     });
 

--- a/server/auth.js
+++ b/server/auth.js
@@ -133,24 +133,25 @@ export function rateLimit(options = {}) {
  */
 export function requireAuth(req, res, next) {
   // Check header first
-  let apiKey = req.headers['x-api-key'] || req.headers['authorization']?.replace('Bearer ', '');
-  
+  let credential = req.headers['x-api-key'] || req.headers['authorization']?.replace('Bearer ', '');
+
   // Fallback to query parameter (less secure, use with caution)
-  if (!apiKey) {
-    apiKey = req.query.apiKey;
+  if (!credential) {
+    credential = req.query.apiKey;
   }
-  
-  if (!apiKey) {
+
+  if (!credential) {
     return res.status(401).json({ error: 'API key required' });
   }
-  
-  if (!isValidApiKey(apiKey)) {
+
+  // Accept either a valid API key or a valid session token
+  if (!isValidApiKey(credential) && !validateSession(credential)) {
     logSecurityEvent('invalid_api_key', { ip: req.ip, path: req.path });
     return res.status(403).json({ error: 'Invalid API key' });
   }
-  
+
   req.authenticated = true;
-  req.apiKey = apiKey;
+  req.apiKey = credential;
   next();
 }
 

--- a/server/index.js
+++ b/server/index.js
@@ -224,6 +224,16 @@ app.get('/api/health', rateLimit({ windowMs: 60000, maxRequests: 120 }), (req, r
   );
 });
 
+// Local browser token - no API key needed, localhost only
+app.get('/api/auth/local-token', rateLimit({ windowMs: 60000, maxRequests: 30 }), (req, res) => {
+  const ip = req.socket.remoteAddress;
+  if (ip !== '127.0.0.1' && ip !== '::1' && ip !== '::ffff:127.0.0.1') {
+    return res.status(403).json({ error: 'Local access only' });
+  }
+  const token = createSession('local-browser');
+  res.json({ token });
+});
+
 // ============================================
 // PROTECTED ENDPOINTS (require authentication)
 // ============================================


### PR DESCRIPTION
Browser client never authenticated after connecting, causing the server to close the connection after the 10s auth timeout and triggering a permanent disconnect/reconnect loop (~12s cycle).

- server/index.js: add GET /api/auth/local-token (localhost-only, no API key required) so the browser can obtain a session token
- public/js/app.js: on ws.onopen, fetch local token and send { type: 'auth', token } before the auth timeout fires; propagate token to voice and office modules
- server/auth.js: requireAuth now accepts session tokens via Authorization: Bearer in addition to API keys, fixing 401s on /api/weather and /api/voice/* endpoints
- public/js/voice.js: setToken() + pass Authorization header on transcribe and speak fetches
- public/js/office.js: setToken() + pass Authorization header on weather fetch

Fixes #2