### PR TITLE
feat: customizable agent names, colors, and voices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ sessions/
 
 # Uploads (if any)
 uploads/
+
+# Claude Code
+CLAUDE.md

--- a/config/ui.json.example
+++ b/config/ui.json.example
@@ -3,16 +3,22 @@
     "main": {
       "name": "Jansky",
       "color": "#FFD700",
+      "hairColor": "#FFD700",
+      "clothColor": "#998100",
       "voice": "onyx"
     },
     "claw-1": {
       "name": "Orbit",
       "color": "#00DDFF",
+      "hairColor": "#00DDFF",
+      "clothColor": "#008499",
       "voice": "echo"
     },
     "claw-2": {
       "name": "Nova",
       "color": "#AA66FF",
+      "hairColor": "#AA66FF",
+      "clothColor": "#663D99",
       "voice": "fable"
     }
   }

--- a/config/ui.json.example
+++ b/config/ui.json.example
@@ -1,0 +1,19 @@
+{
+  "agents": {
+    "main": {
+      "name": "Jansky",
+      "color": "#FFD700",
+      "voice": "onyx"
+    },
+    "claw-1": {
+      "name": "Orbit",
+      "color": "#00DDFF",
+      "voice": "echo"
+    },
+    "claw-2": {
+      "name": "Nova",
+      "color": "#AA66FF",
+      "voice": "fable"
+    }
+  }
+}

--- a/public/js/office.js
+++ b/public/js/office.js
@@ -102,9 +102,9 @@ export async function init(canvasId) {
 
   // Defaults — used immediately and overridden once config loads
   const agentDefs = [
-    { id: 'main',   xPct: 0.50, yPct: 0.18, color: '#FFD700', name: 'Jansky', isBoss: true  },
-    { id: 'claw-1', xPct: 0.22, yPct: 0.48, color: '#00DDFF', name: 'Orbit',  isBoss: false },
-    { id: 'claw-2', xPct: 0.78, yPct: 0.48, color: '#AA66FF', name: 'Nova',   isBoss: false },
+    { id: 'main',   xPct: 0.50, yPct: 0.18, color: '#FFD700', hairColor: '#FFD700', clothColor: darken('#FFD700', 0.4), name: 'Jansky', isBoss: true  },
+    { id: 'claw-1', xPct: 0.22, yPct: 0.48, color: '#00DDFF', hairColor: '#00DDFF', clothColor: darken('#00DDFF', 0.4), name: 'Orbit',  isBoss: false },
+    { id: 'claw-2', xPct: 0.78, yPct: 0.48, color: '#AA66FF', hairColor: '#AA66FF', clothColor: darken('#AA66FF', 0.4), name: 'Nova',   isBoss: false },
   ];
 
   try {
@@ -113,15 +113,17 @@ export async function init(canvasId) {
       const uiConfig = await res.json();
       for (const def of agentDefs) {
         const cfg = uiConfig.agents?.[def.id];
-        if (cfg?.name)  def.name  = cfg.name;
-        if (cfg?.color) def.color = cfg.color;
+        if (cfg?.name)       def.name       = cfg.name;
+        if (cfg?.color)      def.color      = cfg.color;
+        if (cfg?.hairColor)  def.hairColor  = cfg.hairColor;
+        if (cfg?.clothColor) def.clothColor = cfg.clothColor;
       }
     }
   } catch (err) {
     console.warn('[office] Failed to fetch /api/ui-config, using defaults:', err.message);
   }
 
-  agents = agentDefs.map(d => createAgent(d.id, d.xPct, d.yPct, d.color, d.name, d.isBoss));
+  agents = agentDefs.map(d => createAgent(d.id, d.xPct, d.yPct, d.color, d.hairColor, d.clothColor, d.name, d.isBoss));
 
   fetchWeather();
   fetchHealth();
@@ -134,9 +136,9 @@ function resize() {
   canvas.height = rect.height - headerH;
 }
 
-function createAgent(id, xPct, yPct, color, label, isBoss) {
+function createAgent(id, xPct, yPct, color, hairColor, clothColor, label, isBoss) {
   return {
-    id, homeX: xPct, homeY: yPct, xPct, yPct, color, label, isBoss,
+    id, homeX: xPct, homeY: yPct, xPct, yPct, color, hairColor, clothColor, label, isBoss,
     state: 'idle', wanderState: 'at_desk', wanderTarget: null,
     wanderTimer: randomWanderDelay(), wanderIdleTimer: 0,
     stateTimer: 0, animFrame: 0, thoughtText: '', typingDots: 0,
@@ -825,7 +827,7 @@ function drawScreenContent(mx, my, w, h, agent) {
 
 function drawAgent(agent) {
   const x = Math.floor(canvas.width * agent.xPct), y = Math.floor(canvas.height * agent.yPct);
-  const t = tick / 1000, color = agent.color, dark = darken(color, 0.4);
+  const t = tick / 1000, color = agent.color, hairColor = agent.hairColor, clothColor = agent.clothColor;
   const ax = x, ay = y + PX * 5;
   const bob = agent.state === 'idle' ? Math.sin(t * 1.5) * PX * 0.3 : 0;
 
@@ -837,7 +839,7 @@ function drawAgent(agent) {
 
   ctx.fillStyle = '#D4A574';
   drawPixelPattern([' XX ','XXXX','XXXX',' XX '], ax - PX * 2, ay - PX * 6 + bob + headYOff, PX);
-  ctx.fillStyle = color;
+  ctx.fillStyle = hairColor;
   pixel(ax - PX, ay - PX * 7 + bob + headYOff, PX); pixel(ax, ay - PX * 7 + bob + headYOff, PX); pixel(ax + PX, ay - PX * 7 + bob + headYOff, PX);
   pixel(ax - PX * 2, ay - PX * 6 + bob + headYOff, PX); pixel(ax + PX * 2, ay - PX * 6 + bob + headYOff, PX);
   if (agent.isBoss) { ctx.fillStyle = '#FFD700'; pixel(ax, ay - PX * 8 + bob + headYOff, PX); }
@@ -847,7 +849,7 @@ function drawAgent(agent) {
   const eyeY = ay - PX * 5 + bob + headYOff + (agent.lookUp ? -PX * 0.3 : 0);
   pixel(ax - PX, eyeY, PX * 0.7); pixel(ax + PX, eyeY, PX * 0.7);
 
-  ctx.fillStyle = dark;
+  ctx.fillStyle = clothColor;
   drawPixelPattern([' XX ','XXXX','XXXX'], ax - PX * 2 + leanBack, ay - PX * 2 + bob, PX);
   ctx.fillStyle = '#D4A574';
   if (agent.state === 'working') {
@@ -874,26 +876,26 @@ function drawAgent(agent) {
 
 function drawWalkingAgent(agent) {
   const x = Math.floor(canvas.width * agent.xPct), y = Math.floor(canvas.height * agent.yPct);
-  const color = agent.color, dark = darken(color, 0.4);
+  const color = agent.color, hairColor = agent.hairColor, clothColor = agent.clothColor;
   const bounce = Math.abs(Math.sin(agent.walkPhase * 3)) * PX * 1.5;
   const legSwing = Math.sin(agent.walkPhase * 6);
   const ax = x, ay = y - bounce;
 
   ctx.fillStyle = '#D4A574';
   drawPixelPattern([' XX ','XXXX','XXXX',' XX '], ax - PX * 2, ay - PX * 8, PX);
-  ctx.fillStyle = color;
+  ctx.fillStyle = hairColor;
   pixel(ax - PX, ay - PX * 9, PX); pixel(ax, ay - PX * 9, PX); pixel(ax + PX, ay - PX * 9, PX);
   pixel(ax - PX * 2, ay - PX * 8, PX); pixel(ax + PX * 2, ay - PX * 8, PX);
   if (agent.isBoss) { ctx.fillStyle = '#FFD700'; pixel(ax, ay - PX * 10, PX); }
   ctx.fillStyle = '#111';
   const eO = agent.facingRight ? PX * 0.3 : -PX * 0.3;
   pixel(ax - PX + eO, ay - PX * 7, PX * 0.7); pixel(ax + PX + eO, ay - PX * 7, PX * 0.7);
-  ctx.fillStyle = dark;
+  ctx.fillStyle = clothColor;
   drawPixelPattern([' XX ','XXXX','XXXX'], ax - PX * 2, ay - PX * 4, PX);
   ctx.fillStyle = '#D4A574';
   const aS = Math.sin(agent.walkPhase * 6) * PX;
   pixel(ax - PX * 3, ay - PX * 3 + aS, PX); pixel(ax + PX * 2, ay - PX * 3 - aS, PX);
-  ctx.fillStyle = dark;
+  ctx.fillStyle = clothColor;
   const lx = ax - PX + legSwing * PX, rx = ax + legSwing * -PX;
   pixel(lx, ay - PX, PX); pixel(lx, ay, PX); pixel(rx, ay - PX, PX); pixel(rx, ay, PX);
   ctx.fillStyle = '#333'; pixel(lx, ay + PX, PX); pixel(rx, ay + PX, PX);

--- a/public/js/office.js
+++ b/public/js/office.js
@@ -93,18 +93,35 @@ let huddleTopicIndex = 0;
 
 // --- Init & Data Fetching ---
 
-export function init(canvasId) {
+export async function init(canvasId) {
   canvas = document.getElementById(canvasId);
   ctx = canvas.getContext('2d');
   ctx.imageSmoothingEnabled = false;
   resize();
   window.addEventListener('resize', resize);
 
-  agents = [
-    createAgent('main', 0.50, 0.18, '#FFD700', 'Jansky', true),
-    createAgent('claw-1', 0.22, 0.48, '#00DDFF', 'Orbit', false),
-    createAgent('claw-2', 0.78, 0.48, '#AA66FF', 'Nova', false),
+  // Defaults — used immediately and overridden once config loads
+  const agentDefs = [
+    { id: 'main',   xPct: 0.50, yPct: 0.18, color: '#FFD700', name: 'Jansky', isBoss: true  },
+    { id: 'claw-1', xPct: 0.22, yPct: 0.48, color: '#00DDFF', name: 'Orbit',  isBoss: false },
+    { id: 'claw-2', xPct: 0.78, yPct: 0.48, color: '#AA66FF', name: 'Nova',   isBoss: false },
   ];
+
+  try {
+    const res = await fetch('/api/ui-config');
+    if (res.ok) {
+      const uiConfig = await res.json();
+      for (const def of agentDefs) {
+        const cfg = uiConfig.agents?.[def.id];
+        if (cfg?.name)  def.name  = cfg.name;
+        if (cfg?.color) def.color = cfg.color;
+      }
+    }
+  } catch (err) {
+    console.warn('[office] Failed to fetch /api/ui-config, using defaults:', err.message);
+  }
+
+  agents = agentDefs.map(d => createAgent(d.id, d.xPct, d.yPct, d.color, d.name, d.isBoss));
 
   fetchWeather();
   fetchHealth();

--- a/server/index.js
+++ b/server/index.js
@@ -224,6 +224,35 @@ app.get('/api/health', rateLimit({ windowMs: 60000, maxRequests: 120 }), (req, r
   );
 });
 
+// UI config - agent display names, colors, voices
+app.get('/api/ui-config', rateLimit({ windowMs: 60000, maxRequests: 120 }), (req, res) => {
+  const defaults = {
+    agents: {
+      'main':   { name: 'Jansky', color: '#FFD700', voice: 'onyx'  },
+      'claw-1': { name: 'Orbit',  color: '#00DDFF', voice: 'echo'  },
+      'claw-2': { name: 'Nova',   color: '#AA66FF', voice: 'fable' },
+    },
+  };
+  const configPath = join(__dirname, '..', 'config', 'ui.json');
+  if (existsSync(configPath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(configPath, 'utf8'));
+      // Merge: only override known agent IDs and known fields
+      for (const agentId of ['main', 'claw-1', 'claw-2']) {
+        if (parsed.agents?.[agentId]) {
+          const { name, color, voice } = parsed.agents[agentId];
+          if (name  && typeof name  === 'string') defaults.agents[agentId].name  = name;
+          if (color && typeof color === 'string') defaults.agents[agentId].color = color;
+          if (voice && typeof voice === 'string') defaults.agents[agentId].voice = voice;
+        }
+      }
+    } catch (err) {
+      console.warn('[ui-config] Failed to parse config/ui.json, using defaults:', err.message);
+    }
+  }
+  res.json(defaults);
+});
+
 // Local browser token - no API key needed, localhost only
 app.get('/api/auth/local-token', rateLimit({ windowMs: 60000, maxRequests: 30 }), (req, res) => {
   const ip = req.socket.remoteAddress;

--- a/server/index.js
+++ b/server/index.js
@@ -228,9 +228,9 @@ app.get('/api/health', rateLimit({ windowMs: 60000, maxRequests: 120 }), (req, r
 app.get('/api/ui-config', rateLimit({ windowMs: 60000, maxRequests: 120 }), (req, res) => {
   const defaults = {
     agents: {
-      'main':   { name: 'Jansky', color: '#FFD700', voice: 'onyx'  },
-      'claw-1': { name: 'Orbit',  color: '#00DDFF', voice: 'echo'  },
-      'claw-2': { name: 'Nova',   color: '#AA66FF', voice: 'fable' },
+      'main':   { name: 'Jansky', color: '#FFD700', hairColor: '#FFD700', clothColor: '#998100', voice: 'onyx'  },
+      'claw-1': { name: 'Orbit',  color: '#00DDFF', hairColor: '#00DDFF', clothColor: '#008499', voice: 'echo'  },
+      'claw-2': { name: 'Nova',   color: '#AA66FF', hairColor: '#AA66FF', clothColor: '#663D99', voice: 'fable' },
     },
   };
   const configPath = join(__dirname, '..', 'config', 'ui.json');
@@ -240,10 +240,12 @@ app.get('/api/ui-config', rateLimit({ windowMs: 60000, maxRequests: 120 }), (req
       // Merge: only override known agent IDs and known fields
       for (const agentId of ['main', 'claw-1', 'claw-2']) {
         if (parsed.agents?.[agentId]) {
-          const { name, color, voice } = parsed.agents[agentId];
-          if (name  && typeof name  === 'string') defaults.agents[agentId].name  = name;
-          if (color && typeof color === 'string') defaults.agents[agentId].color = color;
-          if (voice && typeof voice === 'string') defaults.agents[agentId].voice = voice;
+          const { name, color, hairColor, clothColor, voice } = parsed.agents[agentId];
+          if (name       && typeof name       === 'string') defaults.agents[agentId].name       = name;
+          if (color      && typeof color      === 'string') defaults.agents[agentId].color      = color;
+          if (hairColor  && typeof hairColor  === 'string') defaults.agents[agentId].hairColor  = hairColor;
+          if (clothColor && typeof clothColor === 'string') defaults.agents[agentId].clothColor = clothColor;
+          if (voice      && typeof voice      === 'string') defaults.agents[agentId].voice      = voice;
         }
       }
     } catch (err) {

--- a/server/voice.js
+++ b/server/voice.js
@@ -1,5 +1,10 @@
 import OpenAI from 'openai';
+import { readFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import config from './config.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 let openai = null;
 
@@ -25,15 +30,28 @@ export async function transcribe(audioBuffer, filename = 'audio.webm') {
   return result.text;
 }
 
-// Agent → voice mapping
-// main (Jansky): onyx — deep, authoritative boss voice
-// claw-1 (Coder): echo — clear, precise technical voice
-// claw-2 (Research): fable — warm, narrative storytelling voice
-const AGENT_VOICES = {
-  'main': 'onyx',
-  'claw-1': 'echo',
-  'claw-2': 'fable',
-};
+// Agent → voice mapping — loaded from config/ui.json if present, else defaults
+const DEFAULT_VOICES = { 'main': 'onyx', 'claw-1': 'echo', 'claw-2': 'fable' };
+
+function loadAgentVoices() {
+  const configPath = join(__dirname, '..', 'config', 'ui.json');
+  if (existsSync(configPath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(configPath, 'utf8'));
+      const voices = { ...DEFAULT_VOICES };
+      for (const agentId of ['main', 'claw-1', 'claw-2']) {
+        const v = parsed.agents?.[agentId]?.voice;
+        if (v && typeof v === 'string') voices[agentId] = v;
+      }
+      return voices;
+    } catch (err) {
+      console.warn('[voice] Failed to parse config/ui.json, using default voices:', err.message);
+    }
+  }
+  return DEFAULT_VOICES;
+}
+
+const AGENT_VOICES = loadAgentVoices();
 
 export async function speak(text, agentId = 'main') {
   const client = getClient();


### PR DESCRIPTION
## Summary

- Adds `config/ui.json.example` — copy to `config/ui.json` to customize each agent's UI appearance and TTS voice
- Each agent exposes four customizable fields:
  - `name`: canvas label displayed below the character
  - `color`: identity color (label text, kanban dots, speech bubbles, highlight ring)
  - `hairColor`: pixel art hair color (defaults to `color`)
  - `clothColor`: pixel art body/clothes/legs color (defaults to darkened `color`)
  - `voice`: OpenAI TTS voice (`onyx`, `echo`, `fable`, `nova`, `alloy`, `shimmer`)
- New `GET /api/ui-config` public endpoint serves the merged config to the client (falls back to defaults if file is missing or malformed)
- `public/js/office.js` fetches config on init so canvas labels, hair, and outfit colors all update dynamically
- `server/voice.js` loads TTS voice mappings from the same config at startup

Agent IDs (`main`, `claw-1`, `claw-2`) remain hardwired internally — only the UI layer is customizable.

Closes #2

## Test plan

- [x] Copy `config/ui.json.example` → `config/ui.json`, change a name/color, reload — canvas label and outfit color update
- [x] Delete `config/ui.json` — falls back to Jansky/Orbit/Nova defaults without errors
- [x] Introduce bad JSON in `config/ui.json` — server logs a warning and serves defaults
- [x] Set `hairColor` and `clothColor` to distinct values — hair and body render independently with correct colors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)