### PR TITLE
feat: customizable office background colors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ uploads/
 
 # Claude Code
 CLAUDE.md
+OFFICE_CANVAS.md

--- a/config/ui.json.example
+++ b/config/ui.json.example
@@ -21,5 +21,11 @@
       "clothColor": "#663D99",
       "voice": "fable"
     }
+  },
+  "background": {
+    "wall":       "#141828",
+    "wallAccent": "#1A2040",
+    "floor":      "#1A1E2E",
+    "floorLine":  "#222840"
   }
 }

--- a/public/js/office.js
+++ b/public/js/office.js
@@ -51,6 +51,14 @@ let sessionStats = { exchanges: 0, tasksCompleted: 0, startTime: Date.now() };
 let audioCtx = null;
 let soundCooldowns = { click: 0, ding: 0, chime: 0 };
 
+// Background color config — overridden by /api/ui-config
+let bgConfig = {
+  wall:       '#141828',
+  wallAccent: '#1A2040',
+  floor:      '#1A1E2E',
+  floorLine:  '#222840',
+};
+
 // Furniture positions
 const FURNITURE = {
   waterCooler:  { xPct: 0.07, yPct: 0.52 },
@@ -117,6 +125,13 @@ export async function init(canvasId) {
         if (cfg?.color)      def.color      = cfg.color;
         if (cfg?.hairColor)  def.hairColor  = cfg.hairColor;
         if (cfg?.clothColor) def.clothColor = cfg.clothColor;
+      }
+      const bg = uiConfig.background;
+      if (bg) {
+        if (bg.wall        && typeof bg.wall        === 'string') bgConfig.wall        = bg.wall;
+        if (bg.wallAccent  && typeof bg.wallAccent  === 'string') bgConfig.wallAccent  = bg.wallAccent;
+        if (bg.floor       && typeof bg.floor       === 'string') bgConfig.floor       = bg.floor;
+        if (bg.floorLine   && typeof bg.floorLine   === 'string') bgConfig.floorLine   = bg.floorLine;
       }
     }
   } catch (err) {
@@ -467,10 +482,10 @@ function isNightTime() {
 function drawRoom(isNight) {
   const w = canvas.width, h = canvas.height, wallH = h * 0.32;
 
-  ctx.fillStyle = PALETTE.wall; ctx.fillRect(0, 0, w, wallH);
-  ctx.fillStyle = PALETTE.wallAccent; ctx.fillRect(0, wallH - PX, w, PX);
-  ctx.fillStyle = PALETTE.floor; ctx.fillRect(0, wallH, w, h - wallH);
-  ctx.fillStyle = PALETTE.floorLine;
+  ctx.fillStyle = bgConfig.wall; ctx.fillRect(0, 0, w, wallH);
+  ctx.fillStyle = bgConfig.wallAccent; ctx.fillRect(0, wallH - PX, w, PX);
+  ctx.fillStyle = bgConfig.floor; ctx.fillRect(0, wallH, w, h - wallH);
+  ctx.fillStyle = bgConfig.floorLine;
   for (let y = wallH; y < h; y += PX * 8) ctx.fillRect(0, y, w, 1);
   for (let x = 0; x < w; x += PX * 12) ctx.fillRect(x, wallH, 1, h - wallH);
 

--- a/server/index.js
+++ b/server/index.js
@@ -232,6 +232,12 @@ app.get('/api/ui-config', rateLimit({ windowMs: 60000, maxRequests: 120 }), (req
       'claw-1': { name: 'Orbit',  color: '#00DDFF', hairColor: '#00DDFF', clothColor: '#008499', voice: 'echo'  },
       'claw-2': { name: 'Nova',   color: '#AA66FF', hairColor: '#AA66FF', clothColor: '#663D99', voice: 'fable' },
     },
+    background: {
+      wall:       '#141828',
+      wallAccent: '#1A2040',
+      floor:      '#1A1E2E',
+      floorLine:  '#222840',
+    },
   };
   const configPath = join(__dirname, '..', 'config', 'ui.json');
   if (existsSync(configPath)) {
@@ -247,6 +253,13 @@ app.get('/api/ui-config', rateLimit({ windowMs: 60000, maxRequests: 120 }), (req
           if (clothColor && typeof clothColor === 'string') defaults.agents[agentId].clothColor = clothColor;
           if (voice      && typeof voice      === 'string') defaults.agents[agentId].voice      = voice;
         }
+      }
+      if (parsed.background) {
+        const { wall, wallAccent, floor, floorLine } = parsed.background;
+        if (wall       && typeof wall       === 'string') defaults.background.wall       = wall;
+        if (wallAccent && typeof wallAccent === 'string') defaults.background.wallAccent = wallAccent;
+        if (floor      && typeof floor      === 'string') defaults.background.floor      = floor;
+        if (floorLine  && typeof floorLine  === 'string') defaults.background.floorLine  = floorLine;
       }
     } catch (err) {
       console.warn('[ui-config] Failed to parse config/ui.json, using defaults:', err.message);


### PR DESCRIPTION
## Summary

- Extends the existing `config/ui.json` customization pattern to the room background
- Four fields configurable under a `background` key:
  - `wall`: top 32% of the canvas (behind agents and whiteboard)
  - `wallAccent`: thin border line at the wall/floor junction
  - `floor`: bottom 68% of the canvas
  - `floorLine`: grid lines drawn across the floor
- Furniture, whiteboard, widgets (clock, weather), plants, ceiling lights, and night overlay remain hardcoded and unchanged

## Test plan

- [x] Set custom `wall`/`floor` colors in `config/ui.json` → reload → room theme changes
- [x] Delete `config/ui.json` → reload → original dark navy/blue defaults restored
- [x] Agent customization (`name`, `color`, `hairColor`, `clothColor`, `voice`) still works unchanged
- [ ] `/api/ui-config` response includes `background` section with correct default values

🤖 Generated with [Claude Code](https://claude.ai/claude-code)